### PR TITLE
Track current depth

### DIFF
--- a/analyser/go/util.go
+++ b/analyser/go/util.go
@@ -2,92 +2,93 @@ package analyser
 
 import (
 	"go/ast"
-	"go/token"	
+	"go/token"
 )
 
 type FileContext struct {
-    Globals []string
+	Globals []string
 }
 
 type FunctionContext struct {
-    Name string
-    SymbolTable SymbolTable
-    CurrentDepth int
-    MaxDepth int
-    Malloc int
+	Name          string
+	SymbolTable   SymbolTable
+	CurrentDepth  int
+	MaxDepth      int
+	CurrentMalloc int
+    MaxMalloc     int
 }
 
 func NewFunctionContext() *FunctionContext {
-    return &FunctionContext{}
+	return &FunctionContext{}
 }
 
 type FunctionInfo struct {
-	Name                string
-	TimeComplexityIndex int
-    SpaceComplexityIndex int
-    SymbolTable         SymbolTable
+	Name                 string
+	TimeComplexityIndex  int
+	SpaceComplexityIndex int
+	SymbolTable          SymbolTable
 }
 
 func (functionContext *FunctionContext) GetFunctionInfo() FunctionInfo {
-    return FunctionInfo {
-        Name: functionContext.Name,
-        TimeComplexityIndex: functionContext.MaxDepth,
-        SpaceComplexityIndex: functionContext.Malloc,
-        SymbolTable: functionContext.SymbolTable,
-    }
+	return FunctionInfo{
+		Name:                 functionContext.Name,
+		TimeComplexityIndex:  functionContext.MaxDepth,
+		SpaceComplexityIndex: functionContext.MaxMalloc,
+		SymbolTable:          functionContext.SymbolTable,
+	}
 }
 
 type SymbolTable struct {
-    Locals []string
-    Params []string
-    Globals []string
+	Locals  []string
+	Params  []string
+	Globals []string
 }
 
-func (st * SymbolTable) IsParam(name string) bool {
-    for _, param := range st.Params {
-        if (param == name){
-            return true
-        }
-    }
-    return false
+func (st *SymbolTable) IsParam(name string) bool {
+	for _, param := range st.Params {
+		if param == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (analyser *FileContext) getSymbolTableForFunction(function *ast.FuncDecl) SymbolTable {
-    // var symbolTable SymbolTable
-    symbolTable := SymbolTable{
-        Globals: analyser.Globals, 
-    }   
+	// var symbolTable SymbolTable
+	symbolTable := SymbolTable{
+		Globals: analyser.Globals,
+	}
 
-    // add parameters from the function AST
-    for _, params := range function.Type.Params.List {
-        for _, param := range params.Names {
-            symbolTable.Params = append(symbolTable.Params, param.Name)
-        }
-    }
-    // add short variable declarations (assignments) from the function AST
-    for _, stmt := range function.Body.List {
-        if assingStmt, ok := stmt.(*ast.AssignStmt); ok && assingStmt.Tok == token.DEFINE {
-            for _, exp := range assingStmt.Lhs{
-                if identifier, ok := exp.(*ast.Ident); ok{
-                    symbolTable.Locals = append(symbolTable.Locals, identifier.Name)
-                }
-            }
-        }
-    }
-    // add variable declarations from the function AST
-    for _, stmt := range function.Body.List {
-        if declStmt, ok := stmt.(*ast.DeclStmt); ok {
-            if genDecl, ok := declStmt.Decl.(*ast.GenDecl); ok && genDecl.Tok == token.VAR {
-                for _, spec := range genDecl.Specs {
-                    if valueSpec, ok := spec.(*ast.ValueSpec); ok {
-                        for _, identifier := range valueSpec.Names {
-                            symbolTable.Locals = append(symbolTable.Locals, identifier.Name)
-                        }
-                    }
-                }
-            }
-        }
-    }
+	// add parameters from the function AST
+	for _, params := range function.Type.Params.List {
+		for _, param := range params.Names {
+			symbolTable.Params = append(symbolTable.Params, param.Name)
+		}
+	}
+	// add short variable declarations (assignments) from the function AST
+	for _, stmt := range function.Body.List {
+		if assingStmt, ok := stmt.(*ast.AssignStmt); ok && assingStmt.Tok == token.DEFINE {
+			for _, exp := range assingStmt.Lhs {
+				if identifier, ok := exp.(*ast.Ident); ok {
+					symbolTable.Locals = append(symbolTable.Locals, identifier.Name)
+				}
+			}
+		}
+	}
+	// add variable declarations from the function AST
+	for _, stmt := range function.Body.List {
+		if declStmt, ok := stmt.(*ast.DeclStmt); ok {
+			if genDecl, ok := declStmt.Decl.(*ast.GenDecl); ok && genDecl.Tok == token.VAR {
+				for _, spec := range genDecl.Specs {
+					if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+						for _, identifier := range valueSpec.Names {
+							symbolTable.Locals = append(symbolTable.Locals, identifier.Name)
+						}
+					}
+				}
+			}
+		}
+	}
 
-    return symbolTable
+	return symbolTable
 }

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -31,7 +31,7 @@ func analyse(cmd *cobra.Command, args []string) {
 
 func printFunctionReport(fn analyser.FunctionInfo) {
 
-	spaceExpected := map[string]int{
+	spaceExpected := map[string]float32{
     "constantSpace":         0,
     "linearSpace":           1,
     "linearAppend":          1,
@@ -50,7 +50,7 @@ func printFunctionReport(fn analyser.FunctionInfo) {
 	}	
 
 	// Hardcoded timeExpected values
-	timeExpected := map[string]int{
+	timeExpected := map[string]float32{
 		"addNumbers":      0,
 		"countToTen":      0,
 		"printItems":      1,
@@ -59,6 +59,7 @@ func printFunctionReport(fn analyser.FunctionInfo) {
 		"labeledBreak":    2,
 		"conditionalLoop": 1,
 		"loopInSwitch":    0,
+		"recursion":       1,
 	}
 	// spaceExpected := map[string]int{
 	// 	"addNumbers":       0,
@@ -91,24 +92,29 @@ func printFunctionReport(fn analyser.FunctionInfo) {
 	
 
     fmt.Printf(
-    "Func: %-15s | Time: %-7s %s | Space: %-2d %s | Params: %v | Locals: %v | Globals: %v\n",
+    "Func: %-15s | Time: %-7s %s | Space: %-7s %s | FanOut=%d | Params: %v | Locals: %v | Globals: %v\n",
     fn.Name,
     parseIndexToTimeComplexity(fn.TimeComplexityIndex),
     tcSymbol,
-    fn.SpaceComplexityIndex,
+    parseIndexToTimeComplexity(fn.SpaceComplexityIndex),
     scSymbol,
+	fn.FanOut,
     fn.SymbolTable.Params,
     fn.SymbolTable.Locals,
     fn.SymbolTable.Globals,
 )   
 }
 
-func parseIndexToTimeComplexity(maxLoopDepth int) string {
+func parseIndexToTimeComplexity(maxLoopDepth float32) string {
 	switch maxLoopDepth {
 	case 0:
 		return "O(1)"
+	case 0.5:
+		return "O(log n)"
 	case 1:
 		return "O(n)"
+	case 1.5:
+		return "O(n*log n)"
 	}
-	return "O(n^" + strconv.Itoa(maxLoopDepth) + ")"
+	return "O(n^" + strconv.Itoa(int(maxLoopDepth)) + ")"
 }

--- a/cmd/analyse.go
+++ b/cmd/analyse.go
@@ -50,16 +50,16 @@ func printFunctionReport(fn analyser.FunctionInfo) {
 	}	
 
 	// Hardcoded timeExpected values
-	// timeExpected := map[string]int{
-	// 	"addNumbers":      0,
-	// 	"countToTen":      0,
-	// 	"printItems":      1,
-	// 	"nestedLoop":      2,
-	// 	"loopForever":     1,
-	// 	"labeledBreak":    2,
-	// 	"conditionalLoop": 1,
-	// 	"loopInSwitch":    0,
-	// }
+	timeExpected := map[string]int{
+		"addNumbers":      0,
+		"countToTen":      0,
+		"printItems":      1,
+		"nestedLoop":      2,
+		"loopForever":     0,
+		"labeledBreak":    2,
+		"conditionalLoop": 1,
+		"loopInSwitch":    0,
+	}
 	// spaceExpected := map[string]int{
 	// 	"addNumbers":       0,
 	// 	"countToTen":       0,
@@ -74,16 +74,16 @@ func printFunctionReport(fn analyser.FunctionInfo) {
 	// }
 
 
-	// expectedTC := timeExpected[fn.Name]
+	expectedTC := timeExpected[fn.Name]
 	expectedSC := spaceExpected[fn.Name]
 
-	// tcCorrect := fn.TimeComplexityIndex == expectedTC
+	tcCorrect := fn.TimeComplexityIndex == expectedTC
 	scCorrect := fn.SpaceComplexityIndex == expectedSC
 
-	// tcSymbol := "❌"
-	// if tcCorrect {
-	// 	tcSymbol = "✅"
-	// }
+	tcSymbol := "❌"
+	if tcCorrect {
+		tcSymbol = "✅"
+	}
 	scSymbol := "❌"
 	if scCorrect {
 		scSymbol = "✅"
@@ -91,11 +91,10 @@ func printFunctionReport(fn analyser.FunctionInfo) {
 	
 
     fmt.Printf(
-		// | Time: %-7s %s
-    "Func: %-15s | Space: %-2d %s | Params: %v | Locals: %v | Globals: %v\n",
+    "Func: %-15s | Time: %-7s %s | Space: %-2d %s | Params: %v | Locals: %v | Globals: %v\n",
     fn.Name,
-    // parseIndexToTimeComplexity(fn.TimeComplexityIndex),
-    // tcSymbol,
+    parseIndexToTimeComplexity(fn.TimeComplexityIndex),
+    tcSymbol,
     fn.SpaceComplexityIndex,
     scSymbol,
     fn.SymbolTable.Params,

--- a/test_data/boss.go
+++ b/test_data/boss.go
@@ -1,0 +1,41 @@
+package testdata
+
+func (analyser *FileContext) getSymbolTableForFunction(function *ast.FuncDecl) SymbolTable {
+    // var symbolTable SymbolTable
+    symbolTable := SymbolTable{
+        Globals: analyser.Globals, 
+    }   
+
+    // add parameters from the function AST
+    for _, params := range function.Type.Params.List {
+        for _, param := range params.Names {
+            symbolTable.Params = append(symbolTable.Params, param.Name)
+        }
+    }
+    // add short variable declarations (assignments) from the function AST
+    for _, stmt := range function.Body.List {
+        if assingStmt, ok := stmt.(*ast.AssignStmt); ok && assingStmt.Tok == token.DEFINE {
+            for _, exp := range assingStmt.Lhs{
+                if identifier, ok := exp.(*ast.Ident); ok{
+                    symbolTable.Locals = append(symbolTable.Locals, identifier.Name)
+                }
+            }
+        }
+    }
+    // add variable declarations from the function AST
+    for _, stmt := range function.Body.List {
+        if declStmt, ok := stmt.(*ast.DeclStmt); ok {
+            if genDecl, ok := declStmt.Decl.(*ast.GenDecl); ok && genDecl.Tok == token.VAR {
+                for _, spec := range genDecl.Specs {
+                    if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+                        for _, identifier := range valueSpec.Names {
+                            symbolTable.Locals = append(symbolTable.Locals, identifier.Name)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return symbolTable
+}

--- a/test_data/sorting_algos.go
+++ b/test_data/sorting_algos.go
@@ -1,0 +1,45 @@
+package main
+
+import "fmt"
+
+func BubbleSort(array[] int)[]int {
+   for i:=0; i< len(array)-1; i++ {
+      for j:=0; j < len(array)-i-1; j++ {
+         if (array[j] > array[j+1]) {
+            array[j], array[j+1] = array[j+1], array[j]
+         }
+      }
+   }
+   return array
+}
+
+func SelectionSort(array[] int, size int) []int {
+   var min_index int
+   var temp int
+   for i := 0; i < size - 1; i++ {
+      min_index = i
+      for j := i + 1; j < size; j++ {
+         if array[j] < array[min_index] {
+            min_index = j
+         }
+      }
+      temp = array[i]
+      array[i] = array[min_index]
+      array[min_index] = temp
+   }
+   return array
+}
+
+func InsertionSort(arr []int) []int {
+    for i := 1; i < len(arr); i++ {
+        key := arr[i]
+        j := i - 1
+        for j >= 0 && arr[j] > key {
+            arr[j+1] = arr[j]
+            j = j - 1
+        }
+        arr[j+1] = key
+    }
+    return arr
+}
+

--- a/test_data/sorting_algos.go
+++ b/test_data/sorting_algos.go
@@ -43,3 +43,58 @@ func InsertionSort(arr []int) []int {
     return arr
 }
 
+func MergeSort(arr []int) []int {
+	if len(arr) <= 1 {
+		return arr
+	}
+
+	mid := len(arr) / 2
+	left := MergeSort(arr[:mid])
+	right := MergeSort(arr[mid:])
+
+	return merge(left, right)
+}
+
+func merge(left, right []int) []int {
+	result := make([]int, 0, len(left)+len(right))
+	i, j := 0, 0
+
+	for i < len(left) && j < len(right) {
+		if left[i] <= right[j] {
+			result = append(result, left[i])
+			i++
+		} else {
+			result = append(result, right[j])
+			j++
+		}
+	}
+
+	result = append(result, left[i:]...)
+	result = append(result, right[j:]...)
+
+	return result
+}
+
+
+func QuickSort(arr []int, low, high int) {
+	if low < high {
+		pivotIdx := partition(arr, low, high)
+		QuickSort(arr, low, pivotIdx-1)
+		QuickSort(arr, pivotIdx+1, high)
+	}
+}
+
+func partition(arr []int, low, high int) int {
+	pivot := arr[high]
+	i := low - 1
+
+	for j := low; j < high; j++ {
+		if arr[j] < pivot {
+			i++
+			arr[i], arr[j] = arr[j], arr[i]
+		}
+	}
+
+	arr[i+1], arr[high] = arr[high], arr[i+1]
+	return i + 1
+}

--- a/test_data/time_test.go
+++ b/test_data/time_test.go
@@ -27,7 +27,7 @@ func printItems(items []string) {
 }
 
 func nestedLoop(n int) {
-	for i := 0; i < n; i++ {
+	for i := 0; i < n -1 ; i++ {
 		for j := 0; j < n; j++ {
 			fmt.Println(i, j)
 		}


### PR DESCRIPTION
- Depth and memory allocation are calculated in the right way, using a stack approach of expanding and shrinking instead of just adding up for every element
- Recursive complexity logic is added. Fan-out detection added with a future printing logic: if a fan-out factor is more than 1, tell user and suggest a link to an article of multiple recursion calls
- Sorting algorithms test cases added